### PR TITLE
Fix Julia requirement for CategoricalArrays 0.3.14

### DIFF
--- a/CategoricalArrays/versions/0.3.14/requires
+++ b/CategoricalArrays/versions/0.3.14/requires
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 Missings
 Reexport
 Compat 0.67.0


### PR DESCRIPTION
Contrary to expectations, this version wasn't actually tested on Julia 0.6 and it fails to load.